### PR TITLE
Migrated to napari plugin engine version 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@
 -e .
 
 # development requirements
-matplotlib==3.4.3
-napari==0.4.12
+matplotlib>=3.4.3
+napari>=0.4.12
 napari_plugin_engine==0.2.0
-numpy==1.21.4
-pytest==6.2.5
-qtpy==1.11.2
+numpy>=1.21.4
+pytest>=6.2.5
+qtpy>=1.11.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,18 +31,23 @@ packages = find:
 python_requires = >=3.7
 package_dir =
     =src
-
 # add your package requirements here
 install_requires =
-    matplotlib
-    napari
-    napari-plugin-engine>=0.1.4
-    numpy
-    qtpy
+    matplotlib>=3.4.3
+    napari>=0.4.12
+    napari-plugin-engine==0.2.0
+    numpy>=1.21.4
+    pytest>=6.2.5
+    qtpy>=1.11.2
+include_package_data = True
 
 [options.packages.find]
 where = src
 
-[options.entry_points] 
-napari.plugin = 
-    napari-time_series_plotter = napari_time_series_plotter
+[options.entry_points]
+napari.manifest =
+    napari-time_series_plotter = napari_time_series_plotter:napari.yaml
+
+[options.package_data]
+napari_time_series_plotter = napari.yaml
+

--- a/src/napari_time_series_plotter/__init__.py
+++ b/src/napari_time_series_plotter/__init__.py
@@ -1,4 +1,0 @@
-
-__version__ = "0.0.2"
-
-from ._dock_widget import napari_experimental_provide_dock_widget

--- a/src/napari_time_series_plotter/_dock_widget.py
+++ b/src/napari_time_series_plotter/_dock_widget.py
@@ -12,21 +12,19 @@ Non image layers or layers with more ore less dimensions will be ignored by the 
 The widgets are send to the viewer through the ``napari_experimental_provide_dock_widget`` hook specification.
 see: https://napari.org/docs/dev/plugins/hook_specifications.html
 """
+
 import matplotlib
 import napari.layers
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_qt5agg import FigureCanvas
-# from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-
-from napari.layers.image import Image
-from napari_plugin_engine import napari_hook_implementation
-
 import numpy as np
-
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
+from napari.layers.image import Image
 from qtpy.QtCore import Signal, Slot, QObject
 from qtpy.QtWidgets import QDialog, QWidget, QVBoxLayout
 
 from ._widgets import TSPCheckBox
+
+# from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 
 matplotlib.use('QT5Agg')
 
@@ -202,8 +200,7 @@ class VoxelPlotter(QDialog):
         """
         self.selected_layers = selected_layers
 
-    @staticmethod
-    def _extract_voxel_time_series(cpos, nlayer):
+    def _extract_voxel_time_series(self, cpos, nlayer):
         """Method to extract the array element values along the first axis of a napari viewer layer.
 
         First the data array is extracted from a napari image layer and the cursor position is
@@ -257,9 +254,3 @@ class VoxelPlotter(QDialog):
             # redraw figure
             self.ax.legend(loc=1)
             self.fig.canvas.draw()
-
-
-@napari_hook_implementation
-def napari_experimental_provide_dock_widget():
-    # you can return either a single widget, or a sequence of widgets
-    return [LayerSelector, VoxelPlotter]

--- a/src/napari_time_series_plotter/_tests/test_dock_widget.py
+++ b/src/napari_time_series_plotter/_tests/test_dock_widget.py
@@ -1,9 +1,9 @@
 """
 Napari-time_series_plotter test module.
 """
-from napari_time_series_plotter._dock_widget import *
 import pytest
-import numpy as np
+
+from napari_time_series_plotter._dock_widget import *
 
 
 # fixture for LayerSelector class tests
@@ -172,10 +172,6 @@ def test_extract_voxel_time_series(plotter: VoxelPlotter, monkeypatch):
 
 
 # test functions
-def test_napari_experimental_provide_dock_widget():
-    assert all([a == b for a, b in zip([LayerSelector, VoxelPlotter], napari_experimental_provide_dock_widget())])
-
-
 def test_tspcheckbox():
     class MockLayer:
         name = 'test'

--- a/src/napari_time_series_plotter/napari.yaml
+++ b/src/napari_time_series_plotter/napari.yaml
@@ -1,0 +1,15 @@
+name: napari-time-series-plotter
+schema_version: 0.1.0
+contributions:
+  commands:
+    - id: napari-time-series-plotter.LayerSelector
+      title: Create Layer Selector
+      python_name: napari_time_series_plotter._dock_widget:LayerSelector
+    - id: napari-time-series-plotter.VoxelPlotter
+      title: Create Voxel Plotter
+      python_name: napari_time_series_plotter._dock_widget:VoxelPlotter
+  widgets:
+    - command: napari-time-series-plotter.LayerSelector
+      display_name: Layer Selector
+    - command: napari-time-series-plotter.VoxelPlotter
+      display_name: Voxel Plotter


### PR DESCRIPTION
No major issues during migration.
Removed the napari_experimental_provide_dock_widget function and coresponding tests.
Updated requirements and setup.cfg to current state.