### PR TITLE
Try to Fix compatibility with new napari mpl api

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
     =src
 # add your package requirements here
 install_requires =
-    napari_matplotlib<1.0
+    napari_matplotlib
     numpy
     pandas
     qtpy

--- a/src/napari_time_series_plotter/widgets.py
+++ b/src/napari_time_series_plotter/widgets.py
@@ -76,6 +76,7 @@ class VoxelPlotter(NapariMPLWidget):
     """
     def __init__(self, napari_viewer, selector, options=None):
         super().__init__(napari_viewer)
+        self.layers_checked = None
         self.selector = selector
         self.cursor_pos = np.array([])
         self.selection_layer = None
@@ -110,8 +111,8 @@ class VoxelPlotter(NapariMPLWidget):
         """
         handles = []
 
-        if self.layers:
-            for layer in self.layers:
+        if self.layers_checked:
+            for layer in self.layers_checked:
                 # get layer data
                 if self.max_label_len:
                     lname = layer.name[slice(self.max_label_len)]
@@ -213,7 +214,7 @@ class VoxelPlotter(NapariMPLWidget):
         """
         Overwrite the layers attribute with the currently checked items in the selector model and re-draw.
         """
-        self.layers = self.selector.model().get_checked()
+        self.layers_checked = self.selector.model().get_checked()
         self._draw()
 
     def update_options(self, options_dict: dict):
@@ -281,7 +282,7 @@ class VoxelPlotter(NapariMPLWidget):
         If event contains 'Shift' and layer attribute contains napari layers the cursor position is written to the
         cursor_pos attribute and the _draw method is called afterwards.
         """
-        if 'Shift' in event.modifiers and self.layers:
+        if 'Shift' in event.modifiers and self.layers_checked:
             self.cursor_pos = np.round(viewer.cursor.position)
             self._draw()
 


### PR DESCRIPTION
This is mostly a demo to remake the plotting functionality using the latest napari-matplotlib widget and not intended to be a fix.
Here I have renamed the variable self.layers, which I believe is creating conflicts from the self.layers object from the main viewer.
The changes allow plotting in ROI mode only. No test has been doing in the other modes (points, voxel).

To reproduce the plotting, install the package in a clean environment, load an image (t, x, y) an draw some rois, then tick on the given image layer selector and the plot profiles of the ROIS should appear.

The canvas layout for some reasons is destroyed (need to be actually carefully checked with the new napari-matplotlib).

I hope this is a good start to investigate the actual issue(s) with this changes.

Appreciate feedback, hints and ideas where to go further...,

cheers 
